### PR TITLE
Add AWS Secret manager integration to Container Definition

### DIFF
--- a/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/aws/RegisterTaskDefinitionRequestBuilder.java
+++ b/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/aws/RegisterTaskDefinitionRequestBuilder.java
@@ -73,6 +73,11 @@ public class RegisterTaskDefinitionRequestBuilder {
             });
         }
 
+        if (isNotBlank(elasticAgentProfileProperties.getExecutionRoleArn())) {
+                LOG.info(format("[create-agent] Adding execution Role to task configuration: {0}", elasticAgentProfileProperties.getExecutionRoleArn()));
+                request.withExecutionRoleArn(elasticAgentProfileProperties.getExecutionRoleArn());
+        }
+
         return request;
     }
 }

--- a/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/domain/ElasticAgentProfileProperties.java
+++ b/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/domain/ElasticAgentProfileProperties.java
@@ -48,6 +48,9 @@ public class ElasticAgentProfileProperties {
     public static final String TASK_ROLE_ARN = "TaskRoleArn";
     public static final String SECURITY_GROUP_IDS = "SecurityGroupIds";
     public static final String SUBNET_IDS = "SubnetIds";
+    public static final String SECRET_NAME = "SecretName";
+    public static final String SECRET_VALUE = "SecretValue";
+    public static final String EXECUTION_ROLE_ARN = "ExecutionRoleArn";
     public static final String PLATFORM = "Platform";
     public static final String BIND_MOUNT = "BindMount";
     public static final String RUN_AS_SPOT_INSTANCE = "RunAsSpotInstance";
@@ -113,6 +116,21 @@ public class ElasticAgentProfileProperties {
     @SerializedName(SUBNET_IDS)
     @Metadata(key = SUBNET_IDS, required = false, secure = false)
     private String subnetIds;
+
+    @Expose
+    @SerializedName(SECRET_NAME)
+    @Metadata(key = SECRET_NAME, required = false, secure = false)
+    private String secretName;
+
+    @Expose
+    @SerializedName(SECRET_VALUE)
+    @Metadata(key = SECRET_VALUE, required = false, secure = false)
+    private String secretValue;
+
+    @Expose
+    @SerializedName(EXECUTION_ROLE_ARN)
+    @Metadata(key = EXECUTION_ROLE_ARN, required = false, secure = false)
+    private String executionRoleArn;
 
     @Expose
     @SerializedName(SECURITY_GROUP_IDS)
@@ -191,6 +209,18 @@ public class ElasticAgentProfileProperties {
 
     public List<String> getSubnetIds() {
         return listFromCommaSeparatedString(subnetIds);
+    }
+
+    public String getSecretName() {
+        return stripToEmpty(secretName);
+    }
+
+    public String getSecretValue() {
+        return stripToEmpty(secretValue);
+    }
+
+    public String getExecutionRoleArn() {
+        return executionRoleArn;
     }
 
     public List<String> getSecurityGroupIds() {

--- a/src/main/resources/profile.template.html
+++ b/src/main/resources/profile.template.html
@@ -313,6 +313,45 @@
         </div>
       </div>
 
+      <div>
+        <label ng-class="{'is-invalid-label': GOINPUTNAME[SecretName].$error.server}">
+          Secret name
+        </label>
+        <input ng-class="{'is-invalid-input': GOINPUTNAME[SecretName].$error.server}" type="text" ng-model="SecretName"
+               ng-required="true" placeholder="e.g. subnet-xyz, subnet-abc"/>
+        <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[SecretName].$error.server}"
+              ng-show="GOINPUTNAME[SecretName].$error.server">{{GOINPUTNAME[SecretName].$error.server}}</span>
+        <div class="form-help-content-one-line">
+          The environment variable where the Secret value will be assigned to and accesible from the ECS task
+        </div>
+      </div>
+
+      <div>
+        <label ng-class="{'is-invalid-label': GOINPUTNAME[SecretValue].$error.server}">
+          Secret value (ARN)
+        </label>
+        <input ng-class="{'is-invalid-input': GOINPUTNAME[SecretValue].$error.server}" type="text" ng-model="SecretValue"
+               ng-required="true" placeholder="e.g. secret name"/>
+        <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[SecretValue].$error.server}"
+              ng-show="GOINPUTNAME[SecretValue].$error.server">{{GOINPUTNAME[SecretValue].$error.server}}</span>
+        <div class="form-help-content-one-line">
+          The secret to expose to the container. The supported values are either the full ARN of the AWS Secrets Manager secret or the full ARN of the parameter in the AWS Systems Manager Parameter Store.
+        </div>
+      </div>
+
+      <div>
+        <label ng-class="{'is-invalid-label': GOINPUTNAME[ExecutionRoleArn].$error.server}">
+          Execution Role Arn
+        </label>
+        <input ng-class="{'is-invalid-input': GOINPUTNAME[ExecutionRoleArn].$error.server}" type="text" ng-model="ExecutionRoleArn"
+               ng-required="true" placeholder="e.g. arn:aws:iam::account-id:role/executionRoleName"/>
+        <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[ExecutionRoleArn].$error.server}"
+              ng-show="GOINPUTNAME[ExecutionRoleArn].$error.server">{{GOINPUTNAME[ExecutionRoleArn].$error.server}}</span>
+        <div class="form-help-content-one-line">
+          The Amazon Resource Name (ARN) of the task execution role that grants the Amazon ECS container agent permission to make AWS API calls on your behalf.
+        </div>
+      </div>
+
       <div class="form_item_block">
         <input type="checkbox" ng-model="RunAsSpotInstance" ng-required="false" ng-true-value="true"
                ng-false-value="false"/>

--- a/src/test/java/com/thoughtworks/gocd/elasticagent/ecs/domain/ElasticAgentProfilePropertiesTest.java
+++ b/src/test/java/com/thoughtworks/gocd/elasticagent/ecs/domain/ElasticAgentProfilePropertiesTest.java
@@ -114,6 +114,27 @@ class ElasticAgentProfilePropertiesTest {
                 "    }\n" +
                 "  },\n" +
                 "  {\n" +
+                "    \"key\": \"SecretName\",\n" +
+                "    \"metadata\": {\n" +
+                "      \"required\": false,\n" +
+                "      \"secure\": false\n" +
+                "    }\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"key\": \"SecretValue\",\n" +
+                "    \"metadata\": {\n" +
+                "      \"required\": false,\n" +
+                "      \"secure\": false\n" +
+                "    }\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"key\": \"ExecutionRoleArn\",\n" +
+                "    \"metadata\": {\n" +
+                "      \"required\": false,\n" +
+                "      \"secure\": false\n" +
+                "    }\n" +
+                "  },\n" +
+                "  {\n" +
                 "    \"key\": \"SecurityGroupIds\",\n" +
                 "    \"metadata\": {\n" +
                 "      \"required\": false,\n" +
@@ -178,6 +199,9 @@ class ElasticAgentProfilePropertiesTest {
                 "  \"AMI\": \"ami-123456\",\n" +
                 "  \"InstanceType\": \"t2.small\",\n" +
                 "  \"SubnetIds\": \"subnet-abc045we\",\n" +
+                "  \"SecretName\": \"secret-name\",\n" +
+                "  \"SecretValue\": \"secret-value\",\n" +
+                "  \"ExecutionRoleArn\": \"executionRoleArn\",\n" +
                 "  \"SecurityGroupIds\": \"sg-ec33sl0,sg-ec33sl2,sg-ec33sl1\",\n" +
                 "  \"EC2TerminateAfter\": \"240\",\n" +
                 "  \"IAMInstanceProfile\": \"ecsInstanceRole\",\n" +
@@ -197,6 +221,9 @@ class ElasticAgentProfilePropertiesTest {
         assertThat(elasticAgentProfileProperties.getAmiID()).isEqualTo("ami-123456");
         assertThat(elasticAgentProfileProperties.getInstanceType()).isEqualTo("t2.small");
         assertThat(elasticAgentProfileProperties.getSubnetIds()).contains("subnet-abc045we");
+        assertThat(elasticAgentProfileProperties.getSecretName()).isEqualTo("secret-name");
+        assertThat(elasticAgentProfileProperties.getSecretValue()).isEqualTo("secret-value");
+        assertThat(elasticAgentProfileProperties.getExecutionRoleArn()).isEqualTo("executionRoleArn");
         assertThat(elasticAgentProfileProperties.getSecurityGroupIds()).contains("sg-ec33sl0", "sg-ec33sl2", "sg-ec33sl1");
         assertThat(elasticAgentProfileProperties.getEC2IamInstanceProfile()).isEqualTo("ecsInstanceRole");
         assertThat(elasticAgentProfileProperties.isPrivileged()).isEqualTo(true);

--- a/src/test/java/com/thoughtworks/gocd/elasticagent/ecs/executors/GetProfileMetadataExecutorTest.java
+++ b/src/test/java/com/thoughtworks/gocd/elasticagent/ecs/executors/GetProfileMetadataExecutorTest.java
@@ -131,6 +131,27 @@ class GetProfileMetadataExecutorTest {
                 "    }\n" +
                 "  },\n" +
                 "  {\n" +
+                "    \"key\": \"SecretName\",\n" +
+                "    \"metadata\": {\n" +
+                "      \"required\": false,\n" +
+                "      \"secure\": false\n" +
+                "    }\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"key\": \"SecretValue\",\n" +
+                "    \"metadata\": {\n" +
+                "      \"required\": false,\n" +
+                "      \"secure\": false\n" +
+                "    }\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"key\": \"ExecutionRoleArn\",\n" +
+                "    \"metadata\": {\n" +
+                "      \"required\": false,\n" +
+                "      \"secure\": false\n" +
+                "    }\n" +
+                "  },\n" +
+                "  {\n" +
                 "    \"key\": \"SecurityGroupIds\",\n" +
                 "    \"metadata\": {\n" +
                 "      \"required\": false,\n" +

--- a/src/test/java/com/thoughtworks/gocd/elasticagent/ecs/executors/GetProfileViewExecutorTest.java
+++ b/src/test/java/com/thoughtworks/gocd/elasticagent/ecs/executors/GetProfileViewExecutorTest.java
@@ -120,7 +120,10 @@ class GetProfileViewExecutorTest {
                 Arguments.of("InstanceType", "Instance type"),
                 Arguments.of("IAMInstanceProfile", "IAM Instance Profile"),
                 Arguments.of("SecurityGroupIds", "Security Group Id(s)"),
-                Arguments.of("SubnetIds", "Subnet id(s)")
+                Arguments.of("SubnetIds", "Subnet id(s)"),
+                Arguments.of("SecretName", "Secret name"),
+                Arguments.of("SecretValue", "Secret value"),
+                Arguments.of("ExecutionRoleArn", "Execution Role Arn")
         );
     }
 


### PR DESCRIPTION
This PR enables a Elastic Profile agent configuration to integrate with the AWS Secrets Manager by adding three new fields to the profile template:

- **Secret name**:  The environment variable where the Secret value will be assigned to and accesible from the ECS task
- **Secret value** (valueFrom): The secret to expose to the container. The supported values are either the full ARN of the AWS Secrets Manager secret or the full ARN of the parameter in the AWS Systems Manager Parameter Store.
- **Execution Role  ARN**: The Amazon Resource Name (ARN) of the task execution role that grants the Amazon ECS container agent permission to make AWS API calls on your behalf.

If all these variables are set and not blank, the following JSON key is added to the ContainerDefinition:

`{
  "containerDefinitions": [{
    "secrets": [{
      "name": "environment_variable_name",
      "valueFrom": "arn:aws:secretsmanager:region:aws_account_id:secret:secret_name-AbCdEf"
    }]
  }]
}`

So far only the "referencing a full secret" use case is implemented as described in https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-secrets.html. Some work still needed to support other use cases such as referencing a specific key within a secret.

Tested successfully on a real production GoCD environment.