### PR TITLE
enable the use of GP3 volumes

### DIFF
--- a/src/main/resources/cluster-profile.template.html
+++ b/src/main/resources/cluster-profile.template.html
@@ -532,6 +532,7 @@ ecs:describeTaskDefinition
               <select ng-model="LinuxOSVolumeType" ng-init="LinuxOSVolumeType = (LinuxOSVolumeType || 'none')">
                 <option value="none">None</option>
                 <option value="gp2">General Purpose SSD (GP2)</option>
+                <option value="gp3">General Purpose SSD (GP3)</option>
                 <option value="io1">Provisioned IOPS SSD (IO1)</option>
                 <option value="sc1">Cold HDD (SC1)</option>
                 <option value="st1">Throughput Optimized HDD (ST1)</option>
@@ -574,6 +575,7 @@ ecs:describeTaskDefinition
                       ng-init="LinuxDockerVolumeType = (LinuxDockerVolumeType || 'none')">
                 <option value="none">None</option>
                 <option value="gp2">General Purpose SSD (GP2)</option>
+                <option value="gp3">General Purpose SSD (GP3)</option>
                 <option value="io1">Provisioned IOPS SSD (IO1)</option>
                 <option value="sc1">Cold HDD (SC1)</option>
                 <option value="st1">Throughput Optimized HDD (ST1)</option>
@@ -788,6 +790,7 @@ ecs:describeTaskDefinition
                       ng-init="WindowsOSVolumeType = (WindowsOSVolumeType || 'none')">
                 <option value="none">None</option>
                 <option value="gp2">General Purpose SSD (GP2)</option>
+                <option value="gp3">General Purpose SSD (GP3)</option>
                 <option value="io1">Provisioned IOPS SSD (IO1)</option>
                 <option value="sc1">Cold HDD (SC1)</option>
                 <option value="st1">Throughput Optimized HDD (ST1)</option>


### PR DESCRIPTION
I've not touched the tests, because GP2 is still a valid default