### PR TITLE
fix: don't let a single AWS error during server-ping cleanup stall agent auto-registration

### DIFF
--- a/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/executors/ServerPingRequestExecutor.java
+++ b/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/executors/ServerPingRequestExecutor.java
@@ -94,7 +94,11 @@ public class ServerPingRequestExecutor implements RequestExecutor {
         List<ClusterProfileProperties> allClusterProfileProperties = serverPingRequest.allClusterProfileProperties();
 
         for (ClusterProfileProperties clusterProfileProperties : allClusterProfileProperties) {
-            performCleanupForCluster(clusterProfileProperties, allAgentInstances.get(clusterProfileProperties.uuid()), doNothingConsoleLogAppender);
+            try {
+                performCleanupForCluster(clusterProfileProperties, allAgentInstances.get(clusterProfileProperties.uuid()), doNothingConsoleLogAppender);
+            } catch (Exception e) {
+                LOG.error(format("[server-ping] Error performing cleanup for cluster {0}.", clusterProfileProperties.getClusterName()), e);
+            }
         }
 
         CheckForPossiblyMissingAgents();
@@ -156,24 +160,28 @@ public class ServerPingRequestExecutor implements RequestExecutor {
     }
 
     private void terminateStoppedInstances(PluginSettings pluginSettings) {
-        final List<Instance> allInstances = containerInstanceHelper.getAllOnDemandInstances(pluginSettings);
+        try {
+            final List<Instance> allInstances = containerInstanceHelper.getAllOnDemandInstances(pluginSettings);
 
-        final EligibleForTerminationPredicate predicate = new EligibleForTerminationPredicate(pluginSettings);
-        final Set<String> instancesToTerminate = allInstances.stream()
-                .filter(predicate)
-                .map(Instance::getInstanceId)
-                .collect(Collectors.toSet());
+            final EligibleForTerminationPredicate predicate = new EligibleForTerminationPredicate(pluginSettings);
+            final Set<String> instancesToTerminate = allInstances.stream()
+                    .filter(predicate)
+                    .map(Instance::getInstanceId)
+                    .collect(Collectors.toSet());
 
-        if (instancesToTerminate.isEmpty()) {
-            LOG.debug("[server-ping] None of the instance is eligible for termination.");
+            if (instancesToTerminate.isEmpty()) {
+                LOG.debug("[server-ping] None of the instance is eligible for termination.");
+            }
+
+            final List<ContainerInstance> containerInstances = containerInstanceHelper.onDemandContainerInstances(pluginSettings);
+            final List<ContainerInstance> containerInstanceList = containerInstances.stream()
+                    .filter(containerInstance -> instancesToTerminate.contains(containerInstance.getEc2InstanceId()))
+                    .collect(toList());
+
+            terminateOperation.execute(pluginSettings, containerInstanceList);
+        } catch (Exception e) {
+            LOG.error("[server-ping] There were errors while terminating stopped instances.", e);
         }
-
-        final List<ContainerInstance> containerInstances = containerInstanceHelper.onDemandContainerInstances(pluginSettings);
-        final List<ContainerInstance> containerInstanceList = containerInstances.stream()
-                .filter(containerInstance -> instancesToTerminate.contains(containerInstance.getEc2InstanceId()))
-                .collect(toList());
-
-        terminateOperation.execute(pluginSettings, containerInstanceList);
     }
 
     private void stopIdleEC2Instance(PluginSettings pluginSettings, EventStream eventStream) {

--- a/src/test/java/com/thoughtworks/gocd/elasticagent/ecs/executors/ServerPingRequestExecutorTest.java
+++ b/src/test/java/com/thoughtworks/gocd/elasticagent/ecs/executors/ServerPingRequestExecutorTest.java
@@ -16,8 +16,10 @@
 
 package com.thoughtworks.gocd.elasticagent.ecs.executors;
 
+import com.amazonaws.services.ec2.model.AmazonEC2Exception;
 import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ecs.model.ContainerInstance;
+import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import com.thoughtworks.gocd.elasticagent.ecs.*;
 import com.thoughtworks.gocd.elasticagent.ecs.aws.ContainerInstanceHelper;
 import com.thoughtworks.gocd.elasticagent.ecs.aws.SpotInstanceService;
@@ -200,6 +202,50 @@ class ServerPingRequestExecutorTest {
         executor.execute();
 
         verify(terminationOperation).execute(clusterProfileProperties, singletonList(stoppedContainerInstance));
+    }
+
+    @Test
+    void shouldCompleteServerPingWhenTerminationOfStoppedInstancesFails() throws Exception {
+        final List<Instance> allInstances = Arrays.asList(
+                instance("i-abcdxyz", RUNNING, LINUX.name()),
+                instance("i-abcd123", STOPPED, LINUX.name())
+        );
+
+        final ContainerInstance stoppedContainerInstance = containerInstance("i-abcd123");
+        final List<ContainerInstance> containerInstances = Arrays.asList(
+                containerInstance("i-abcdxyz"),
+                stoppedContainerInstance
+        );
+
+        when(containerInstanceHelper.getAllOnDemandInstances(clusterProfileProperties)).thenReturn(allInstances);
+        when(containerInstanceHelper.onDemandContainerInstances(clusterProfileProperties)).thenReturn(containerInstances);
+        when(pluginRequest.listAgents()).thenReturn(new Agents(new ArrayList<>()));
+        doThrow(new AmazonEC2Exception("instance is no longer available"))
+                .when(terminationOperation).execute(eq(clusterProfileProperties), anyList());
+
+        final GoPluginApiResponse response = executor.execute();
+
+        assertThat(response.responseCode()).isEqualTo(200);
+    }
+
+    @Test
+    void shouldContinueWithRemainingClustersWhenCleanupForOneClusterFails() throws Exception {
+        final ClusterProfileProperties otherClusterProfileProperties = mock(ClusterProfileProperties.class);
+        when(otherClusterProfileProperties.uuid()).thenReturn("id2");
+        final ECSTasks failingAgentInstances = mock(ECSTasks.class);
+        final ECSTasks otherAgentInstances = mock(ECSTasks.class);
+        when(failingAgentInstances.instancesCreatedAfterTimeout(any(), any())).thenThrow(new AmazonEC2Exception("service unavailable"));
+        when(otherAgentInstances.instancesCreatedAfterTimeout(any(), any())).thenReturn(new Agents());
+        when(otherAgentInstances.getEventStream()).thenReturn(eventStream);
+        when(pluginRequest.listAgents()).thenReturn(new Agents());
+        when(serverPingRequest.allClusterProfileProperties()).thenReturn(List.of(clusterProfileProperties, otherClusterProfileProperties));
+        allAgentInstances.put("id1", failingAgentInstances);
+        allAgentInstances.put("id2", otherAgentInstances);
+
+        final GoPluginApiResponse response = executor.execute();
+
+        verify(otherAgentInstances).instancesCreatedAfterTimeout(eq(otherClusterProfileProperties), any());
+        assertThat(response.responseCode()).isEqualTo(200);
     }
 
     @Test


### PR DESCRIPTION
Fixes #479.

A single `AmazonEC2Exception`/`AmazonECSException` during server-ping cleanup currently propagates out of `ServerPingRequestExecutor.execute()`, failing the entire server-ping. That skips `CheckForPossiblyMissingAgents` and stalls agent auto-approval server-wide: newly spawned elastic agents loop on `403 / pending approval` and every elastic-agent job sits in Scheduled until the underlying AWS state is manually cleaned up (details and production log signatures in #479).

Changes, both consistent with the error handling already used by the sibling cleanup steps (`stopInstances`, `tagSpotInstances`, `ensureClusterSize`, `terminateIdleSpotInstances`):

- `execute()`: wrap each cluster's `performCleanupForCluster` in try/catch, so one cluster's failure cannot abort the ping for the other clusters or skip `CheckForPossiblyMissingAgents`.
- `terminateStoppedInstances()`: wrap the body in try/catch, so a phantom instance (terminated but still visible with stale state in `DescribeInstances` for up to ~an hour) cannot kill the ping.

Tests added:

- server-ping completes (returns success) when termination of stopped instances throws
- remaining clusters still get cleaned up when one cluster's cleanup throws

Full test suite passes.
