### PR TITLE
Add AWS Fargate / Fargate Spot launch type support

### DIFF
--- a/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/ECSTasks.java
+++ b/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/ECSTasks.java
@@ -82,7 +82,10 @@ public class ECSTasks implements AgentInstances<ECSTask> {
         try {
             if (task != null) {
                 taskHelper.stopAndCleanupTask(pluginSettings, task);
-                containerInstanceHelper.checkAndMarkEC2InstanceIdle(pluginSettings, task.getEC2InstanceId());
+                String ec2Id = task.getEC2InstanceId();
+                if (ec2Id != null && !ec2Id.toUpperCase().startsWith("FARGATE")) {
+                    containerInstanceHelper.checkAndMarkEC2InstanceIdle(pluginSettings, ec2Id);
+                }
                 LOG.info(format("Task {0} is terminated.", task.name()));
             } else {
                 LOG.warn(format("Requested to deregister task that does not exist {0}", agentId));

--- a/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/aws/ContainerDefinitionBuilder.java
+++ b/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/aws/ContainerDefinitionBuilder.java
@@ -55,7 +55,7 @@ public class ContainerDefinitionBuilder {
                 .withDockerLabels(labelsFrom())
                 .withCommand(elasticAgentProfileProperties.getCommand())
                 .withCpu(elasticAgentProfileProperties.getCpu())
-                .withPrivileged(elasticAgentProfileProperties.platform() != WINDOWS && elasticAgentProfileProperties.isPrivileged())
+                .withPrivileged(elasticAgentProfileProperties.platform() != WINDOWS && elasticAgentProfileProperties.isPrivileged() && !elasticAgentProfileProperties.isFargate())
                 .withLogConfiguration(pluginSettings.logConfiguration());
     }
 

--- a/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/aws/RegisterTaskDefinitionRequestBuilder.java
+++ b/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/aws/RegisterTaskDefinitionRequestBuilder.java
@@ -35,44 +35,55 @@ public class RegisterTaskDefinitionRequestBuilder {
                 .withContainerDefinitions(containerDefinition)
                 .withTaskRoleArn(StringUtils.defaultIfBlank(elasticAgentProfileProperties.getTaskRoleArn(), null));
 
+        if (elasticAgentProfileProperties.isFargate()) {
+            request.withRequiresCompatibilities(Compatibility.FARGATE);
+            request.setNetworkMode(NetworkMode.Awsvpc);
+            request.setExecutionRoleArn(elasticAgentProfileProperties.getExecutionRoleArn());
+            request.setCpu(String.valueOf(elasticAgentProfileProperties.getCpu()));
+            request.setMemory(String.valueOf(elasticAgentProfileProperties.getMaxMemory()));
+        }
+
         if (elasticAgentProfileProperties.platform() == Platform.WINDOWS) {
             return request;
         }
 
-        if (isNotBlank(pluginSettings.efsDnsOrIP())) {
-            LOG.info(format("[create-agent] Adding EFS volume {0} to task configuration.", pluginSettings.efsDnsOrIP()));
-            request.withVolumes(new Volume()
-                    .withName("efs")
-                    .withHost(new HostVolumeProperties().withSourcePath(pluginSettings.efsMountLocation())));
-
-            request.getContainerDefinitions().getFirst().withMountPoints(new MountPoint()
-                    .withSourceVolume("efs")
-                    .withContainerPath(pluginSettings.efsMountLocation()));
-        }
-
-        if (elasticAgentProfileProperties.isMountDockerSocket()) {
-            LOG.info("[create-agent] Adding /var/run/docker.sock to task configuration.");
-            request.withVolumes(new Volume()
-                    .withName("DockerSocket")
-                    .withHost(new HostVolumeProperties().withSourcePath("/var/run/docker.sock")));
-
-            request.getContainerDefinitions().getFirst()
-                    .withMountPoints(new MountPoint()
-                            .withSourceVolume("DockerSocket")
-                            .withContainerPath("/var/run/docker.sock")
-                    );
-        }
-
-        if (!elasticAgentProfileProperties.bindMounts().isEmpty()) {
-            elasticAgentProfileProperties.bindMounts().forEach(bindMount -> {
+        // Fargate cannot use host-based mount points (EFS host volume, docker socket, bind mounts).
+        if (!elasticAgentProfileProperties.isFargate()) {
+            if (isNotBlank(pluginSettings.efsDnsOrIP())) {
+                LOG.info(format("[create-agent] Adding EFS volume {0} to task configuration.", pluginSettings.efsDnsOrIP()));
                 request.withVolumes(new Volume()
-                        .withName(bindMount.getName())
-                        .withHost(new HostVolumeProperties().withSourcePath(bindMount.getSourcePath()))
-                );
+                        .withName("efs")
+                        .withHost(new HostVolumeProperties().withSourcePath(pluginSettings.efsMountLocation())));
+
                 request.getContainerDefinitions().getFirst().withMountPoints(new MountPoint()
-                        .withSourceVolume(bindMount.getName())
-                        .withContainerPath(bindMount.getContainerPath()));
-            });
+                        .withSourceVolume("efs")
+                        .withContainerPath(pluginSettings.efsMountLocation()));
+            }
+
+            if (elasticAgentProfileProperties.isMountDockerSocket()) {
+                LOG.info("[create-agent] Adding /var/run/docker.sock to task configuration.");
+                request.withVolumes(new Volume()
+                        .withName("DockerSocket")
+                        .withHost(new HostVolumeProperties().withSourcePath("/var/run/docker.sock")));
+
+                request.getContainerDefinitions().getFirst()
+                        .withMountPoints(new MountPoint()
+                                .withSourceVolume("DockerSocket")
+                                .withContainerPath("/var/run/docker.sock")
+                        );
+            }
+
+            if (!elasticAgentProfileProperties.bindMounts().isEmpty()) {
+                elasticAgentProfileProperties.bindMounts().forEach(bindMount -> {
+                    request.withVolumes(new Volume()
+                            .withName(bindMount.getName())
+                            .withHost(new HostVolumeProperties().withSourcePath(bindMount.getSourcePath()))
+                    );
+                    request.getContainerDefinitions().getFirst().withMountPoints(new MountPoint()
+                            .withSourceVolume(bindMount.getName())
+                            .withContainerPath(bindMount.getContainerPath()));
+                });
+            }
         }
 
         return request;

--- a/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/aws/TaskHelper.java
+++ b/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/aws/TaskHelper.java
@@ -71,59 +71,125 @@ public class TaskHelper {
                 .withServerId(getServerId())
                 .build();
 
-        StopPolicy stopPolicy = elasticAgentProfileProperties.platform() == LINUX ? pluginSettings.getLinuxStopPolicy() : pluginSettings.getWindowsStopPolicy();
-        Optional<ContainerInstance> containerInstance = instanceSelectionStrategyFactory
-                .strategyFor(stopPolicy)
-                .instanceForScheduling(pluginSettings, elasticAgentProfileProperties, containerDefinition);
+        if (!elasticAgentProfileProperties.isFargate()) {
+            StopPolicy stopPolicy = elasticAgentProfileProperties.platform() == LINUX ? pluginSettings.getLinuxStopPolicy() : pluginSettings.getWindowsStopPolicy();
+            Optional<ContainerInstance> containerInstance = instanceSelectionStrategyFactory
+                    .strategyFor(stopPolicy)
+                    .instanceForScheduling(pluginSettings, elasticAgentProfileProperties, containerDefinition);
 
-        if (containerInstance.isEmpty()) {
-            consoleLogAppender.accept("No running instance(s) found to build the ECS Task to perform current job.");
-            LOG.info(format("[create-agent] No running instances found to build container with profile {0}", createAgentRequest.elasticProfile().toJson()));
-            if (elasticAgentProfileProperties.runAsSpotInstance()) {
-                spotInstanceService.create(pluginSettings, elasticAgentProfileProperties, consoleLogAppender);
+            if (containerInstance.isEmpty()) {
+                consoleLogAppender.accept("No running instance(s) found to build the ECS Task to perform current job.");
+                LOG.info(format("[create-agent] No running instances found to build container with profile {0}", createAgentRequest.elasticProfile().toJson()));
+                if (elasticAgentProfileProperties.runAsSpotInstance()) {
+                    spotInstanceService.create(pluginSettings, elasticAgentProfileProperties, consoleLogAppender);
+                } else {
+                    containerInstance = Optional.of(containerInstanceHelper.startOrCreateOneInstance(pluginSettings, elasticAgentProfileProperties, consoleLogAppender));
+                }
             } else {
-                containerInstance = Optional.of(containerInstanceHelper.startOrCreateOneInstance(pluginSettings, elasticAgentProfileProperties, consoleLogAppender));
+                consoleLogAppender.accept("Found existing running container instance platform matching ECS Task instance configuration. Not starting a new EC2 instance...");
+            }
+            if (containerInstance.isEmpty()) {
+                return empty();
+            }
+
+            final RegisterTaskDefinitionRequest registerTaskDefinitionRequest = registerTaskDefinitionRequestBuilder
+                    .build(pluginSettings, elasticAgentProfileProperties, containerDefinition).withFamily(taskName);
+
+            consoleLogAppender.accept("Registering ECS Task definition with cluster...");
+            LOG.debug(format("[create-agent] Registering task definition: {0} ", registerTaskDefinitionRequest.toString()));
+            RegisterTaskDefinitionResult taskDefinitionResult = pluginSettings.ecsClient().registerTaskDefinition(registerTaskDefinitionRequest);
+            consoleLogAppender.accept("Done registering ECS Task definition with cluster.");
+            LOG.debug("[create-agent] Done registering task definition");
+
+            TaskDefinition taskDefinitionFromNewTask = taskDefinitionResult.getTaskDefinition();
+            StartTaskRequest startTaskRequest = new StartTaskRequest()
+                    .withTaskDefinition(taskDefinitionFromNewTask.getTaskDefinitionArn())
+                    .withContainerInstances(containerInstance.get().getContainerInstanceArn())
+                    .withCluster(pluginSettings.getClusterName());
+
+            consoleLogAppender.accept("Starting ECS Task to perform current job...");
+            LOG.debug(format("[create-agent] Starting task : {0} ", startTaskRequest.toString()));
+            StartTaskResult startTaskResult = pluginSettings.ecsClient().startTask(startTaskRequest);
+            LOG.debug("[create-agent] Done executing start task request.");
+
+            if (isStarted(startTaskResult)) {
+                String message = elasticAgentProfileProperties.runAsSpotInstance() ?
+                        "[WARNING] The ECS task is scheduled on a Spot Instance. A spot instance termination would re-schedule the job."
+                        : String.format("ECS Task %s scheduled on container instance %s.", taskName, containerInstance.get().getEc2InstanceId());
+
+                consoleLogAppender.accept(message);
+
+                LOG.info(format("[create-agent] Task {0} scheduled on container instance {1}", taskName, containerInstance.get().getEc2InstanceId()));
+                return Optional.of(new ECSTask(startTaskResult.getTasks().getFirst(), taskDefinitionFromNewTask, elasticAgentProfileProperties, createAgentRequest.getJobIdentifier(), createAgentRequest.environment(), containerInstance.get().getEc2InstanceId()));
+            } else {
+                cleanupTaskDefinition(pluginSettings, taskDefinitionFromNewTask.getTaskDefinitionArn());
+                String errors = startTaskResult.getFailures().stream().map(failure -> "    " + failure.getArn() + " failed with reason :" + failure.getReason()).collect(Collectors.joining("\n"));
+                throw new ContainerFailedToRegisterException("Fail to start task " + taskName + ":\n" + errors);
             }
         } else {
-            consoleLogAppender.accept("Found existing running container instance platform matching ECS Task instance configuration. Not starting a new EC2 instance...");
-        }
-        if (containerInstance.isEmpty()) {
-            return empty();
-        }
+            consoleLogAppender.accept("This is an ECS Fargate task request. Not creating an EC2 instance.");
+            LOG.info("[create-agent] This is an ECS Fargate task request. Not creating an EC2 instance.");
 
-        final RegisterTaskDefinitionRequest registerTaskDefinitionRequest = registerTaskDefinitionRequestBuilder
-                .build(pluginSettings, elasticAgentProfileProperties, containerDefinition).withFamily(taskName);
+            final RegisterTaskDefinitionRequest registerTaskDefinitionRequest = registerTaskDefinitionRequestBuilder
+                    .build(pluginSettings, elasticAgentProfileProperties, containerDefinition).withFamily(taskName);
 
-        consoleLogAppender.accept("Registering ECS Task definition with cluster...");
-        LOG.debug(format("[create-agent] Registering task definition: {0} ", registerTaskDefinitionRequest.toString()));
-        RegisterTaskDefinitionResult taskDefinitionResult = pluginSettings.ecsClient().registerTaskDefinition(registerTaskDefinitionRequest);
-        consoleLogAppender.accept("Done registering ECS Task definition with cluster.");
-        LOG.debug("[create-agent] Done registering task definition");
+            consoleLogAppender.accept("Registering ECS Fargate Task definition with cluster...");
+            LOG.debug(format("[create-agent] Registering Fargate task definition: {0} ", registerTaskDefinitionRequest.toString()));
+            RegisterTaskDefinitionResult taskDefinitionResult = pluginSettings.ecsClient().registerTaskDefinition(registerTaskDefinitionRequest);
+            consoleLogAppender.accept("Done registering ECS Fargate Task definition with cluster.");
+            LOG.debug("[create-agent] Done registering Fargate task definition");
 
-        TaskDefinition taskDefinitionFromNewTask = taskDefinitionResult.getTaskDefinition();
-        StartTaskRequest startTaskRequest = new StartTaskRequest()
-                .withTaskDefinition(taskDefinitionFromNewTask.getTaskDefinitionArn())
-                .withContainerInstances(containerInstance.get().getContainerInstanceArn())
-                .withCluster(pluginSettings.getClusterName());
+            TaskDefinition taskDefinitionFromNewTask = taskDefinitionResult.getTaskDefinition();
 
-        consoleLogAppender.accept("Starting ECS Task to perform current job...");
-        LOG.debug(format("[create-agent] Starting task : {0} ", startTaskRequest.toString()));
-        StartTaskResult startTaskResult = pluginSettings.ecsClient().startTask(startTaskRequest);
-        LOG.debug("[create-agent] Done executing start task request.");
+            final EC2Config ec2Config = new EC2Config.Builder()
+                    .withSettings(pluginSettings)
+                    .withProfile(elasticAgentProfileProperties)
+                    .build();
 
-        if (isStarted(startTaskResult)) {
-            String message = elasticAgentProfileProperties.runAsSpotInstance() ?
-                    "[WARNING] The ECS task is scheduled on a Spot Instance. A spot instance termination would re-schedule the job."
-                    : String.format("ECS Task %s scheduled on container instance %s.", taskName, containerInstance.get().getEc2InstanceId());
+            AwsVpcConfiguration awsVpcConfiguration = new AwsVpcConfiguration()
+                    .withSecurityGroups(ec2Config.getSecurityGroups())
+                    .withSubnets(ec2Config.getSubnetIds())
+                    .withAssignPublicIp("ENABLED");
 
-            consoleLogAppender.accept(message);
+            NetworkConfiguration networkConfiguration = new NetworkConfiguration()
+                    .withAwsvpcConfiguration(awsVpcConfiguration);
 
-            LOG.info(format("[create-agent] Task {0} scheduled on container instance {1}", taskName, containerInstance.get().getEc2InstanceId()));
-            return Optional.of(new ECSTask(startTaskResult.getTasks().getFirst(), taskDefinitionFromNewTask, elasticAgentProfileProperties, createAgentRequest.getJobIdentifier(), createAgentRequest.environment(), containerInstance.get().getEc2InstanceId()));
-        } else {
-            cleanupTaskDefinition(pluginSettings, taskDefinitionFromNewTask.getTaskDefinitionArn());
-            String errors = startTaskResult.getFailures().stream().map(failure -> "    " + failure.getArn() + " failed with reason :" + failure.getReason()).collect(Collectors.joining("\n"));
-            throw new ContainerFailedToRegisterException("Fail to start task " + taskName + ":\n" + errors);
+            CapacityProviderStrategyItem capacityProvider = elasticAgentProfileProperties.runAsSpotInstance()
+                    ? new CapacityProviderStrategyItem().withCapacityProvider("FARGATE_SPOT")
+                    : new CapacityProviderStrategyItem().withCapacityProvider("FARGATE");
+
+            consoleLogAppender.accept("Starting ECS Fargate Task to perform current job...");
+            RunTaskResult runTaskResult;
+            try {
+                RunTaskRequest runTaskRequest = new RunTaskRequest()
+                        .withCapacityProviderStrategy(capacityProvider)
+                        .withTaskDefinition(taskDefinitionFromNewTask.getTaskDefinitionArn())
+                        .withCluster(pluginSettings.getClusterName())
+                        .withNetworkConfiguration(networkConfiguration);
+                LOG.debug(format("[create-agent] Starting Fargate task : {0} ", runTaskRequest.toString()));
+                runTaskResult = pluginSettings.ecsClient().runTask(runTaskRequest);
+            } catch (InvalidParameterException e) {
+                LOG.debug(format("[create-agent] Capacity provider strategy rejected ({0}), falling back to launch type FARGATE.", e.getMessage()));
+                RunTaskRequest runTaskRequest = new RunTaskRequest()
+                        .withLaunchType(LaunchType.FARGATE)
+                        .withTaskDefinition(taskDefinitionFromNewTask.getTaskDefinitionArn())
+                        .withCluster(pluginSettings.getClusterName())
+                        .withNetworkConfiguration(networkConfiguration);
+                LOG.debug(format("[create-agent] Starting Fargate task : {0} ", runTaskRequest.toString()));
+                runTaskResult = pluginSettings.ecsClient().runTask(runTaskRequest);
+            }
+            LOG.debug("[create-agent] Done executing run task request.");
+
+            if (isStarted(runTaskResult)) {
+                String fargateInstanceId = "FARGATE-" + UUID.randomUUID().toString().replaceAll("-", "");
+                consoleLogAppender.accept(format("ECS Fargate Task {0} scheduled.", taskName));
+                LOG.info(format("[create-agent] Fargate task {0} scheduled.", taskName));
+                return Optional.of(new ECSTask(runTaskResult.getTasks().get(0), taskDefinitionFromNewTask, elasticAgentProfileProperties, createAgentRequest.getJobIdentifier(), createAgentRequest.environment(), fargateInstanceId));
+            } else {
+                cleanupTaskDefinition(pluginSettings, taskDefinitionFromNewTask.getTaskDefinitionArn());
+                String errors = runTaskResult.getFailures().stream().map(failure -> "    " + failure.getArn() + " failed with reason :" + failure.getReason()).collect(Collectors.joining("\n"));
+                throw new ContainerFailedToRegisterException("Fail to start Fargate task " + taskName + ":\n" + errors);
+            }
         }
     }
 
@@ -227,5 +293,9 @@ public class TaskHelper {
 
     private boolean isStarted(StartTaskResult startTaskResult) {
         return startTaskResult.getFailures().isEmpty() && !startTaskResult.getTasks().isEmpty();
+    }
+
+    private boolean isStarted(RunTaskResult runTaskResult) {
+        return runTaskResult.getFailures().isEmpty() && !runTaskResult.getTasks().isEmpty();
     }
 }

--- a/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/domain/ElasticAgentProfileProperties.java
+++ b/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/domain/ElasticAgentProfileProperties.java
@@ -44,6 +44,7 @@ public class ElasticAgentProfileProperties {
     public static final String AMI = "AMI";
     public static final String INSTANCE_TYPE = "InstanceType";
     public static final String IAM_INSTANCE_PROFILE = "IAMInstanceProfile";
+    public static final String EXECUTION_ROLE_ARN = "ExecutionRoleArn";
     public static final String TASK_ROLE_ARN = "TaskRoleArn";
     public static final String SECURITY_GROUP_IDS = "SecurityGroupIds";
     public static final String SUBNET_IDS = "SubnetIds";
@@ -92,6 +93,16 @@ public class ElasticAgentProfileProperties {
     @SerializedName("Privileged")
     @Metadata(key = "Privileged", required = false, secure = false)
     public String privileged;
+
+    @Expose
+    @SerializedName("Fargate")
+    @Metadata(key = "Fargate", required = false, secure = false)
+    public String fargate;
+
+    @Expose
+    @SerializedName(EXECUTION_ROLE_ARN)
+    @Metadata(key = EXECUTION_ROLE_ARN, required = false, secure = false)
+    public String executionRoleArn;
 
     @Expose
     @SerializedName(TASK_ROLE_ARN)
@@ -211,6 +222,14 @@ public class ElasticAgentProfileProperties {
 
     public String getTaskRoleArn() {
         return taskRoleArn;
+    }
+
+    public String getExecutionRoleArn() {
+        return executionRoleArn;
+    }
+
+    public boolean isFargate() {
+        return parseBoolean(fargate);
     }
 
     public Integer getCpu() {

--- a/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/executors/ServerPingRequestExecutor.java
+++ b/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/executors/ServerPingRequestExecutor.java
@@ -192,6 +192,15 @@ public class ServerPingRequestExecutor implements RequestExecutor {
     private void stopInstances(PluginSettings pluginSettings, Platform platform, EventStream eventStream) {
         try {
             final StopPolicy stopPolicy = platform == LINUX ? pluginSettings.getLinuxStopPolicy() : pluginSettings.getWindowsStopPolicy();
+            // No StopPolicy configured — this is the case for a Fargate-only cluster
+            // (there are no long-lived EC2 container instances to keep-stopped). Skip
+            // cleanly instead of NPE-ing in strategyFor(null).ordinal(). Reaping of
+            // Fargate tasks is handled by terminateDisabledAgents (job completion) and
+            // terminateUnregisteredInstances (auto-register timeout), plus the agent
+            // container's own self-termination.
+            if (stopPolicy == null) {
+                return;
+            }
             final Optional<List<ContainerInstance>> instanceToStop = instanceSelectionStrategyFactory
                     .strategyFor(stopPolicy)
                     .instancesToStop(pluginSettings, platform);

--- a/src/main/resources/profile.template.html
+++ b/src/main/resources/profile.template.html
@@ -112,6 +112,32 @@
         </div>
       </div>
 
+      <div class="col">
+        <input ng-class="{'is-invalid-input': GOINPUTNAME[Fargate].$error.server}" type="checkbox"
+               ng-model="Fargate"
+               ng-required="true" ng-true-value="true" ng-false-value="false" id="Fargate"/>
+        <label ng-class="{'is-invalid-label': GOINPUTNAME[Fargate].$error.server}"
+               for="Fargate">Fargate</label>
+        <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[Fargate].$error.server}"
+              ng-show="GOINPUTNAME[Fargate].$error.server">{{GOINPUTNAME[Fargate].$error.server}}</span>
+        <div class="form-help-content-one-line">
+          Run this task on AWS Fargate (no EC2 instance is launched). Requires an Execution role arn and awsvpc networking.
+        </div>
+      </div>
+
+      <div>
+        <label ng-class="{'is-invalid-label': GOINPUTNAME[ExecutionRoleArn].$error.server}">Execution role arn</label>
+        <input ng-class="{'is-invalid-input': GOINPUTNAME[ExecutionRoleArn].$error.server}" type="text"
+               ng-model="ExecutionRoleArn"
+               ng-required="true" placeholder="e.g. arn:aws:iam::369170619674:role/ecsTaskExecutionRole"/>
+        <span class="form_error form-error"
+              ng-class="{'is-visible': GOINPUTNAME[ExecutionRoleArn].$error.server}"
+              ng-show="GOINPUTNAME[ExecutionRoleArn].$error.server">{{GOINPUTNAME[ExecutionRoleArn].$error.server}}</span>
+        <div class="form-help-content-one-line">
+          IAM role that the ECS Fargate agent uses to pull the image and write logs. Only used when Fargate is enabled.
+        </div>
+      </div>
+
       <div class="col-2" ng-show="Platform == 'linux'">
         <div class="col">
           <input ng-class="{'is-invalid-input': GOINPUTNAME[MountDockerSocket].$error.server}" type="checkbox"

--- a/src/test/java/com/thoughtworks/gocd/elasticagent/ecs/domain/ElasticAgentProfilePropertiesTest.java
+++ b/src/test/java/com/thoughtworks/gocd/elasticagent/ecs/domain/ElasticAgentProfilePropertiesTest.java
@@ -87,6 +87,20 @@ class ElasticAgentProfilePropertiesTest {
                     }
                   },
                   {
+                    "key": "Fargate",
+                    "metadata": {
+                      "required": false,
+                      "secure": false
+                    }
+                  },
+                  {
+                    "key": "ExecutionRoleArn",
+                    "metadata": {
+                      "required": false,
+                      "secure": false
+                    }
+                  },
+                  {
                     "key": "TaskRoleArn",
                     "metadata": {
                       "required": false,

--- a/src/test/java/com/thoughtworks/gocd/elasticagent/ecs/executors/GetProfileMetadataExecutorTest.java
+++ b/src/test/java/com/thoughtworks/gocd/elasticagent/ecs/executors/GetProfileMetadataExecutorTest.java
@@ -104,6 +104,20 @@ class GetProfileMetadataExecutorTest {
                     }
                   },
                   {
+                    "key": "Fargate",
+                    "metadata": {
+                      "required": false,
+                      "secure": false
+                    }
+                  },
+                  {
+                    "key": "ExecutionRoleArn",
+                    "metadata": {
+                      "required": false,
+                      "secure": false
+                    }
+                  },
+                  {
                     "key": "TaskRoleArn",
                     "metadata": {
                       "required": false,


### PR DESCRIPTION
## What this adds

AWS **Fargate** and **Fargate Spot** as an elastic-agent launch type, so agents can run as serverless ECS tasks with no EC2 container instances to provision, scale, or reap.

This re-applies the Fargate work from the (unmerged) #243 by @timothy-cloudopsguy onto current `master`, and irons out a few rough edges found running it in anger.

## How it works

Two new **elastic agent profile** keys:

- `Fargate` — `true` selects the Fargate launch type for that profile.
- `ExecutionRoleArn` — the task execution role (required by Fargate to pull the image / ship logs).

When `Fargate=true`, `create-agent`:

- registers a task definition with `requiresCompatibilities=FARGATE`, `awsvpc` network mode, the execution role, and CPU/memory from the profile;
- runs it with `RunTask` — via a `FARGATE_SPOT`/`FARGATE` **capacity-provider strategy** (falling back to `LaunchType.FARGATE` if capacity providers aren't configured), with an `awsvpc` network configuration built from the profile's subnets + security groups and `AssignPublicIp=ENABLED`;
- skips the EC2-only concerns for Fargate (container-instance selection, `privileged`, host bind/docker-socket mounts).

## Fixes over #243

- **Unique task identity** — Fargate tasks carry a stable `FARGATE-<uuid>` sentinel instead of an EC2 instance id, and the termination path recognises it so it never tries to reclaim a (non-existent) EC2 instance for a Fargate task.
- **`AssignPublicIp=ENABLED`** so tasks in public subnets can pull images / reach the server.
- **Null-`StopPolicy` guard** in the server-ping idle-stop path — a Fargate-only cluster has no EC2 stop policy, which previously NPE'd on every ping (`strategyFor(null)`). Fargate reaping is handled by job-completion teardown + the auto-register timeout.

## Tests

Existing suite passes; profile-metadata expectations updated for the two new keys.

## IAM note

The plugin's role needs the ECS task lifecycle actions plus `ec2:Describe*` and `iam:PassRole` (scoped to the task/execution roles, `iam:PassedToService=ecs-tasks.amazonaws.com`) — the EC2-launch actions (`RunInstances`, etc.) are not required for a Fargate-only setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
