### PR TITLE
Add AWS Fargate / Fargate Spot launch type support (SDK v2)

### DIFF
--- a/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/ECSTasks.java
+++ b/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/ECSTasks.java
@@ -81,7 +81,10 @@ public class ECSTasks implements AgentInstances<ECSTask> {
         try {
             if (task != null) {
                 taskHelper.stopAndCleanupTask(pluginSettings, task);
-                containerInstanceHelper.checkAndMarkEC2InstanceIdle(pluginSettings, task.getEC2InstanceId());
+                String ec2Id = task.getEC2InstanceId();
+                if (ec2Id != null && !ec2Id.toUpperCase().startsWith("FARGATE")) {
+                    containerInstanceHelper.checkAndMarkEC2InstanceIdle(pluginSettings, ec2Id);
+                }
                 LOG.info(format("Task {0} is terminated.", task.name()));
             } else {
                 LOG.warn(format("Requested to deregister task that does not exist {0}", agentId));

--- a/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/aws/ContainerDefinitionBuilder.java
+++ b/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/aws/ContainerDefinitionBuilder.java
@@ -59,7 +59,7 @@ public class ContainerDefinitionBuilder {
                 .environment(environmentFrom())
                 .dockerLabels(labelsFrom())
                 .command(request.elasticProfile().getCommand())
-                .privileged(request.elasticProfile().platform() != WINDOWS && request.elasticProfile().isPrivileged())
+                .privileged(request.elasticProfile().platform() != WINDOWS && request.elasticProfile().isPrivileged() && !request.elasticProfile().isFargate())
                 .logConfiguration(pluginSettings.logConfiguration());
     }
 

--- a/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/aws/RegisterTaskDefinitionRequestBuilder.java
+++ b/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/aws/RegisterTaskDefinitionRequestBuilder.java
@@ -38,6 +38,14 @@ public class RegisterTaskDefinitionRequestBuilder {
                 .family(taskName)
                 .taskRoleArn(StringUtils.defaultIfBlank(elasticAgentProfileProperties.getTaskRoleArn(), null));
 
+        if (elasticAgentProfileProperties.isFargate()) {
+            request.requiresCompatibilities(Compatibility.FARGATE)
+                    .networkMode(NetworkMode.AWSVPC)
+                    .executionRoleArn(elasticAgentProfileProperties.getExecutionRoleArn())
+                    .cpu(String.valueOf(elasticAgentProfileProperties.getCpu()))
+                    .memory(String.valueOf(elasticAgentProfileProperties.getMaxMemory()));
+        }
+
         if (elasticAgentProfileProperties.platform() == Platform.WINDOWS) {
             return request.containerDefinitions(containerDefinitionBuilder.build()).build();
         }
@@ -45,7 +53,8 @@ public class RegisterTaskDefinitionRequestBuilder {
         List<Volume> volumes = new ArrayList<>();
         List<MountPoint> mountPoints = new ArrayList<>();
 
-        if (isNotBlank(pluginSettings.efsDnsOrIP())) {
+        // Fargate rejects host-based mount points (EFS host volume, docker socket, bind mounts), so skip them entirely.
+        if (!elasticAgentProfileProperties.isFargate() && isNotBlank(pluginSettings.efsDnsOrIP())) {
             LOG.info(format("[create-agent] Adding EFS volume {0} to task configuration.", pluginSettings.efsDnsOrIP()));
             volumes.add(Volume.builder()
                     .name("efs")
@@ -58,7 +67,7 @@ public class RegisterTaskDefinitionRequestBuilder {
                     .build());
         }
 
-        if (elasticAgentProfileProperties.isMountDockerSocket()) {
+        if (!elasticAgentProfileProperties.isFargate() && elasticAgentProfileProperties.isMountDockerSocket()) {
             LOG.info("[create-agent] Adding /var/run/docker.sock to task configuration.");
             volumes.add(Volume.builder()
                     .name("DockerSocket")
@@ -71,7 +80,7 @@ public class RegisterTaskDefinitionRequestBuilder {
                     .build());
         }
 
-        if (!elasticAgentProfileProperties.bindMounts().isEmpty()) {
+        if (!elasticAgentProfileProperties.isFargate() && !elasticAgentProfileProperties.bindMounts().isEmpty()) {
             elasticAgentProfileProperties.bindMounts().forEach(bindMount -> {
                 volumes.add(Volume.builder()
                         .name(bindMount.getName())

--- a/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/aws/TaskHelper.java
+++ b/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/aws/TaskHelper.java
@@ -66,6 +66,10 @@ public class TaskHelper {
 
         ContainerDefinitionBuilder containerDefinitionBuilder = new ContainerDefinitionBuilder(createAgentRequest);
 
+        if (elasticAgentProfileProperties.isFargate()) {
+            return createFargateTask(createAgentRequest, pluginSettings, consoleLogAppender, taskName, elasticAgentProfileProperties, containerDefinitionBuilder);
+        }
+
         StopPolicy stopPolicy = elasticAgentProfileProperties.platform() == LINUX ? pluginSettings.getLinuxStopPolicy() : pluginSettings.getWindowsStopPolicy();
         Optional<ContainerInstance> containerInstance = instanceSelectionStrategyFactory
                 .strategyFor(stopPolicy)
@@ -123,6 +127,81 @@ public class TaskHelper {
             cleanupTaskDefinition(pluginSettings, taskDefinitionFromNewTask.taskDefinitionArn());
             String errors = startTaskResult.failures().stream().map(failure -> "    " + failure.arn() + " failed with reason :" + failure.reason()).collect(Collectors.joining("\n"));
             throw new ContainerFailedToRegisterException("Fail to start task " + taskName + ":\n" + errors);
+        }
+    }
+
+    private Optional<ECSTask> createFargateTask(CreateAgentRequest createAgentRequest, PluginSettings pluginSettings, ConsoleLogAppender consoleLogAppender,
+                                                String taskName, ElasticAgentProfileProperties elasticAgentProfileProperties,
+                                                ContainerDefinitionBuilder containerDefinitionBuilder) throws ContainerFailedToRegisterException {
+        consoleLogAppender.accept("This is an ECS Fargate task request. Not creating an EC2 instance.");
+        LOG.info("[create-agent] This is an ECS Fargate task request. Not creating an EC2 instance.");
+
+        final RegisterTaskDefinitionRequest registerTaskDefinitionRequest = registerTaskDefinitionRequestBuilder
+                .build(pluginSettings, elasticAgentProfileProperties, containerDefinitionBuilder.name(taskName)
+                        .pluginSettings(pluginSettings)
+                        .serverId(getServerId())
+                        .build(), taskName);
+
+        consoleLogAppender.accept("Registering ECS Fargate Task definition with cluster...");
+        LOG.debug(format("[create-agent] Registering Fargate task definition: {0} ", registerTaskDefinitionRequest.toString()));
+        RegisterTaskDefinitionResponse taskDefinitionResult = pluginSettings.ecsClient().registerTaskDefinition(registerTaskDefinitionRequest);
+        consoleLogAppender.accept("Done registering ECS Fargate Task definition with cluster.");
+        LOG.debug("[create-agent] Done registering Fargate task definition");
+
+        TaskDefinition taskDefinitionFromNewTask = taskDefinitionResult.taskDefinition();
+
+        final EC2Config ec2Config = new EC2Config.Builder()
+                .settings(pluginSettings)
+                .profile(elasticAgentProfileProperties)
+                .build();
+
+        AwsVpcConfiguration awsVpcConfiguration = AwsVpcConfiguration.builder()
+                .securityGroups(ec2Config.getSecurityGroups())
+                .subnets(ec2Config.getSubnetIds())
+                .assignPublicIp(AssignPublicIp.ENABLED)
+                .build();
+
+        NetworkConfiguration networkConfiguration = NetworkConfiguration.builder()
+                .awsvpcConfiguration(awsVpcConfiguration)
+                .build();
+
+        CapacityProviderStrategyItem capacityProvider = CapacityProviderStrategyItem.builder()
+                .capacityProvider(elasticAgentProfileProperties.runAsSpotInstance() ? "FARGATE_SPOT" : "FARGATE")
+                .build();
+
+        consoleLogAppender.accept("Starting ECS Fargate Task to perform current job...");
+        RunTaskResponse runTaskResult;
+        try {
+            RunTaskRequest runTaskRequest = RunTaskRequest.builder()
+                    .capacityProviderStrategy(capacityProvider)
+                    .taskDefinition(taskDefinitionFromNewTask.taskDefinitionArn())
+                    .cluster(pluginSettings.getClusterName())
+                    .networkConfiguration(networkConfiguration)
+                    .build();
+            LOG.debug(format("[create-agent] Starting Fargate task : {0} ", runTaskRequest.toString()));
+            runTaskResult = pluginSettings.ecsClient().runTask(runTaskRequest);
+        } catch (InvalidParameterException e) {
+            LOG.debug(format("[create-agent] Capacity provider strategy rejected ({0}), falling back to launch type FARGATE.", e.getMessage()));
+            RunTaskRequest runTaskRequest = RunTaskRequest.builder()
+                    .launchType(LaunchType.FARGATE)
+                    .taskDefinition(taskDefinitionFromNewTask.taskDefinitionArn())
+                    .cluster(pluginSettings.getClusterName())
+                    .networkConfiguration(networkConfiguration)
+                    .build();
+            LOG.debug(format("[create-agent] Starting Fargate task : {0} ", runTaskRequest.toString()));
+            runTaskResult = pluginSettings.ecsClient().runTask(runTaskRequest);
+        }
+        LOG.debug("[create-agent] Done executing run task request.");
+
+        if (isStarted(runTaskResult)) {
+            String fargateInstanceId = "FARGATE-" + UUID.randomUUID().toString().replaceAll("-", "");
+            consoleLogAppender.accept(format("ECS Fargate Task {0} scheduled.", taskName));
+            LOG.info(format("[create-agent] Fargate task {0} scheduled.", taskName));
+            return Optional.of(new ECSTask(runTaskResult.tasks().get(0), taskDefinitionFromNewTask, elasticAgentProfileProperties, createAgentRequest.getJobIdentifier(), createAgentRequest.environment(), fargateInstanceId));
+        } else {
+            cleanupTaskDefinition(pluginSettings, taskDefinitionFromNewTask.taskDefinitionArn());
+            String errors = runTaskResult.failures().stream().map(failure -> "    " + failure.arn() + " failed with reason :" + failure.reason()).collect(Collectors.joining("\n"));
+            throw new ContainerFailedToRegisterException("Fail to start Fargate task " + taskName + ":\n" + errors);
         }
     }
 
@@ -223,5 +302,9 @@ public class TaskHelper {
 
     private boolean isStarted(StartTaskResponse startTaskResult) {
         return startTaskResult.failures().isEmpty() && !startTaskResult.tasks().isEmpty();
+    }
+
+    private boolean isStarted(RunTaskResponse runTaskResult) {
+        return runTaskResult.failures().isEmpty() && !runTaskResult.tasks().isEmpty();
     }
 }

--- a/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/domain/ElasticAgentProfileProperties.java
+++ b/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/domain/ElasticAgentProfileProperties.java
@@ -44,6 +44,7 @@ public class ElasticAgentProfileProperties {
     public static final String AMI = "AMI";
     public static final String INSTANCE_TYPE = "InstanceType";
     public static final String IAM_INSTANCE_PROFILE = "IAMInstanceProfile";
+    public static final String EXECUTION_ROLE_ARN = "ExecutionRoleArn";
     public static final String TASK_ROLE_ARN = "TaskRoleArn";
     public static final String SECURITY_GROUP_IDS = "SecurityGroupIds";
     public static final String SUBNET_IDS = "SubnetIds";
@@ -92,6 +93,16 @@ public class ElasticAgentProfileProperties {
     @SerializedName("Privileged")
     @Metadata(key = "Privileged", required = false, secure = false)
     public String privileged;
+
+    @Expose
+    @SerializedName("Fargate")
+    @Metadata(key = "Fargate", required = false, secure = false)
+    public String fargate;
+
+    @Expose
+    @SerializedName(EXECUTION_ROLE_ARN)
+    @Metadata(key = EXECUTION_ROLE_ARN, required = false, secure = false)
+    public String executionRoleArn;
 
     @Expose
     @SerializedName(TASK_ROLE_ARN)
@@ -211,6 +222,14 @@ public class ElasticAgentProfileProperties {
 
     public String getTaskRoleArn() {
         return taskRoleArn;
+    }
+
+    public String getExecutionRoleArn() {
+        return executionRoleArn;
+    }
+
+    public boolean isFargate() {
+        return parseBoolean(fargate);
     }
 
     public Integer getCpu() {

--- a/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/executors/ServerPingRequestExecutor.java
+++ b/src/main/java/com/thoughtworks/gocd/elasticagent/ecs/executors/ServerPingRequestExecutor.java
@@ -192,6 +192,11 @@ public class ServerPingRequestExecutor implements RequestExecutor {
     private void stopInstances(PluginSettings pluginSettings, Platform platform, EventStream eventStream) {
         try {
             final StopPolicy stopPolicy = platform == LINUX ? pluginSettings.getLinuxStopPolicy() : pluginSettings.getWindowsStopPolicy();
+            // No StopPolicy configured (e.g. a Fargate-only cluster) — nothing to stop; return
+            // cleanly instead of NPE-ing in strategyFor(null).
+            if (stopPolicy == null) {
+                return;
+            }
             final Optional<List<ContainerInstance>> instanceToStop = instanceSelectionStrategyFactory
                     .strategyFor(stopPolicy)
                     .instancesToStop(pluginSettings, platform);

--- a/src/main/resources/profile.template.html
+++ b/src/main/resources/profile.template.html
@@ -112,6 +112,32 @@
         </div>
       </div>
 
+      <div class="col">
+        <input ng-class="{'is-invalid-input': GOINPUTNAME[Fargate].$error.server}" type="checkbox"
+               ng-model="Fargate"
+               ng-required="true" ng-true-value="true" ng-false-value="false" id="Fargate"/>
+        <label ng-class="{'is-invalid-label': GOINPUTNAME[Fargate].$error.server}"
+               for="Fargate">Fargate</label>
+        <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[Fargate].$error.server}"
+              ng-show="GOINPUTNAME[Fargate].$error.server">{{GOINPUTNAME[Fargate].$error.server}}</span>
+        <div class="form-help-content-one-line">
+          Run this task on AWS Fargate (no EC2 instance is launched). Requires an Execution role arn and awsvpc networking.
+        </div>
+      </div>
+
+      <div>
+        <label ng-class="{'is-invalid-label': GOINPUTNAME[ExecutionRoleArn].$error.server}">Execution role arn</label>
+        <input ng-class="{'is-invalid-input': GOINPUTNAME[ExecutionRoleArn].$error.server}" type="text"
+               ng-model="ExecutionRoleArn"
+               ng-required="true" placeholder="e.g. arn:aws:iam::369170619674:role/ecsTaskExecutionRole"/>
+        <span class="form_error form-error"
+              ng-class="{'is-visible': GOINPUTNAME[ExecutionRoleArn].$error.server}"
+              ng-show="GOINPUTNAME[ExecutionRoleArn].$error.server">{{GOINPUTNAME[ExecutionRoleArn].$error.server}}</span>
+        <div class="form-help-content-one-line">
+          IAM role that the ECS Fargate agent uses to pull the image and write logs. Only used when Fargate is enabled.
+        </div>
+      </div>
+
       <div class="col-2" ng-show="Platform == 'linux'">
         <div class="col">
           <input ng-class="{'is-invalid-input': GOINPUTNAME[MountDockerSocket].$error.server}" type="checkbox"

--- a/src/test/java/com/thoughtworks/gocd/elasticagent/ecs/domain/ElasticAgentProfilePropertiesTest.java
+++ b/src/test/java/com/thoughtworks/gocd/elasticagent/ecs/domain/ElasticAgentProfilePropertiesTest.java
@@ -88,6 +88,20 @@ class ElasticAgentProfilePropertiesTest {
                     }
                   },
                   {
+                    "key": "Fargate",
+                    "metadata": {
+                      "required": false,
+                      "secure": false
+                    }
+                  },
+                  {
+                    "key": "ExecutionRoleArn",
+                    "metadata": {
+                      "required": false,
+                      "secure": false
+                    }
+                  },
+                  {
                     "key": "TaskRoleArn",
                     "metadata": {
                       "required": false,

--- a/src/test/java/com/thoughtworks/gocd/elasticagent/ecs/executors/GetProfileMetadataExecutorTest.java
+++ b/src/test/java/com/thoughtworks/gocd/elasticagent/ecs/executors/GetProfileMetadataExecutorTest.java
@@ -104,6 +104,20 @@ class GetProfileMetadataExecutorTest {
                     }
                   },
                   {
+                    "key": "Fargate",
+                    "metadata": {
+                      "required": false,
+                      "secure": false
+                    }
+                  },
+                  {
+                    "key": "ExecutionRoleArn",
+                    "metadata": {
+                      "required": false,
+                      "secure": false
+                    }
+                  },
+                  {
                     "key": "TaskRoleArn",
                     "metadata": {
                       "required": false,

--- a/src/test/java/com/thoughtworks/gocd/elasticagent/ecs/executors/ServerPingRequestExecutorTest.java
+++ b/src/test/java/com/thoughtworks/gocd/elasticagent/ecs/executors/ServerPingRequestExecutorTest.java
@@ -20,6 +20,7 @@ import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import com.thoughtworks.gocd.elasticagent.ecs.*;
 import com.thoughtworks.gocd.elasticagent.ecs.aws.ContainerInstanceHelper;
 import com.thoughtworks.gocd.elasticagent.ecs.aws.SpotInstanceService;
+import com.thoughtworks.gocd.elasticagent.ecs.aws.StopPolicy;
 import com.thoughtworks.gocd.elasticagent.ecs.aws.TaskHelper;
 import com.thoughtworks.gocd.elasticagent.ecs.aws.strategy.InstanceSelectionStrategy;
 import com.thoughtworks.gocd.elasticagent.ecs.aws.strategy.InstanceSelectionStrategyFactory;
@@ -303,6 +304,7 @@ class ServerPingRequestExecutorTest {
             final List<Instance> runningInstances = singletonList(runningLinuxInstance("i-abcded1"));
             final List<ContainerInstance> containerInstances = singletonList(containerInstance("i-abcded1"));
 
+            when(clusterProfileProperties.getLinuxStopPolicy()).thenReturn(StopPolicy.StopIdleInstance);
             when(containerInstanceHelper.getAllInstances(clusterProfileProperties)).thenReturn(runningInstances);
             when(containerInstanceHelper.getContainerInstances(clusterProfileProperties)).thenReturn(containerInstances);
             when(instanceSelectionStrategy.instancesToStop(clusterProfileProperties, LINUX)).thenReturn(Optional.of(containerInstances));
@@ -341,6 +343,7 @@ class ServerPingRequestExecutorTest {
             final List<Instance> runningInstances = singletonList(runningWindowsInstance("i-abcded1"));
             final List<ContainerInstance> containerInstances = singletonList(containerInstance("i-abcded1"));
 
+            when(clusterProfileProperties.getWindowsStopPolicy()).thenReturn(StopPolicy.StopIdleInstance);
             when(containerInstanceHelper.getAllInstances(clusterProfileProperties)).thenReturn(runningInstances);
             when(containerInstanceHelper.getContainerInstances(clusterProfileProperties)).thenReturn(containerInstances);
             when(instanceSelectionStrategy.instancesToStop(clusterProfileProperties, WINDOWS)).thenReturn(Optional.of(containerInstances));


### PR DESCRIPTION
## What this adds

AWS **Fargate** and **Fargate Spot** as an elastic-agent launch type, so agents can run as serverless ECS tasks with no EC2 container instances to provision, scale, or reap.

This re-applies the Fargate work from the (unmerged) #243 by @timothy-cloudopsguy onto current `master`, and irons out a few rough edges found running it in anger.

## How it works

Two new **elastic agent profile** keys:

- `Fargate` — `true` selects the Fargate launch type for that profile.
- `ExecutionRoleArn` — the task execution role (required by Fargate to pull the image / ship logs).

When `Fargate=true`, `create-agent`:

- registers a task definition with `requiresCompatibilities=FARGATE`, `awsvpc` network mode, the execution role, and CPU/memory from the profile;
- runs it with `RunTask` — via a `FARGATE_SPOT`/`FARGATE` **capacity-provider strategy** (falling back to `LaunchType.FARGATE` if capacity providers aren't configured), with an `awsvpc` network configuration built from the profile's subnets + security groups and `AssignPublicIp=ENABLED`;
- skips the EC2-only concerns for Fargate (container-instance selection, `privileged`, host bind/docker-socket mounts).

## Fixes over #243

- **Unique task identity** — Fargate tasks carry a stable `FARGATE-<uuid>` sentinel instead of an EC2 instance id, and the termination path recognises it so it never tries to reclaim a (non-existent) EC2 instance for a Fargate task.
- **`AssignPublicIp=ENABLED`** so tasks in public subnets can pull images / reach the server.
- **Null-`StopPolicy` guard** in the server-ping idle-stop path — a Fargate-only cluster has no EC2 stop policy, which previously NPE'd on every ping (`strategyFor(null)`). Fargate reaping is handled by job-completion teardown + the auto-register timeout.

## Tests

Existing suite passes; profile-metadata expectations updated for the two new keys.

## IAM note

The plugin's role needs the ECS task lifecycle actions plus `ec2:Describe*` and `iam:PassRole` (scoped to the task/execution roles, `iam:PassedToService=ecs-tasks.amazonaws.com`) — the EC2-launch actions (`RunInstances`, etc.) are not required for a Fargate-only setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
